### PR TITLE
Update snorql.js

### DIFF
--- a/assets/js/snorql.js
+++ b/assets/js/snorql.js
@@ -1,4 +1,4 @@
-var _endpoint = "http://sparql.wikipathways.org/sparql";
+var _endpoint = "https://sparql.wikipathways.org/sparql";
 var _examples_repo = "https://github.com/wikipathways/SPARQLQueries";
 var _defaultGraph = "";
 var _namespaces = snorql_namespacePrefixes;


### PR DESCRIPTION
The sparql endpoint is not httpS, so the default should point towards that.