### PR TITLE
feat: configurable navbar linkouts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to Snorql-UI
+
+Thanks for improving Snorql-UI. It is a dependency-light, **fully client-side** SPARQL interface — static HTML, CSS, and vanilla JavaScript loaded directly by `index.html` (no bundler, no build step). Contributions should preserve that property.
+
+## Ground rules
+
+- **Target branch:** open pull requests against `master`.
+- **Commit messages:** `type(MM-DD): description`, e.g. `feat(06-18): add config-driven navbar linkouts` or `docs(06-18): document linkouts`. Common types: `feat`, `fix`, `docs`, `test`, `chore`.
+- **Before pushing**, run the same gates CI runs and make sure they pass:
+  ```bash
+  npm ci
+  npm run lint     # eslint assets/js/
+  npm test         # jest (jsdom)
+  ```
+- **Keep changes additive and backwards-compatible.** A new feature must not change behavior for existing deployments unless that is the explicit intent.
+- **No bundler / no new runtime dependencies** without discussion — vendored libraries live as plain files under `assets/`.
+
+## Project layout
+
+| Path | Purpose |
+|------|---------|
+| `assets/js/config.js` | `window.SNORQL_CONFIG` — the single place deployers edit (endpoint, namespaces, renderers, …). |
+| `assets/js/sparql.js` | SPARQL protocol library (`SPARQL.Service`, `SPARQL.Query`). |
+| `assets/js/snorql.js` | Main UI controller — query execution, result rendering, examples, parameters. |
+| `assets/js/script.js` | DOM event handlers (clipboard, permalink, shortcuts). |
+| `index.html` | Loads the scripts (order matters: `config.js` first) and holds the markup. |
+| `__tests__/*.test.js` | Jest tests. Auto-discovered via `**/__tests__/**/*.test.js`. |
+
+## Config-driven UI extensions
+
+The preferred way to add an optional UI feature is to make it **config-driven and isolated**, so it ships off by default, doesn't touch the core controller, and stays easy to merge. `assets/js/linkouts.js` (configurable navbar linkout buttons) is the **reference implementation** of this pattern — read it alongside this section.
+
+The recipe:
+
+1. **One isolated module.** Add `assets/js/<feature>.js` as a self-contained IIFE in the vendored-globals style (no `import`/`require`). Expose a small namespace so it can be unit-tested, and self-initialize on `DOMContentLoaded` (guard the `readyState === 'loading'` race). Example shape — see `linkouts.js` lines 21–122.
+
+2. **A config key with a safe default.** Add the feature's settings to `window.SNORQL_CONFIG` in `assets/js/config.js` with a default that renders nothing / changes nothing (`[]`, `false`, `null`). Existing deployments must be unaffected when they don't opt in. Document the shape in a comment block above the key (`linkouts: []` is the model).
+
+3. **A mount point + correct load order.** Add any required element to `index.html` (e.g. an empty `<ul id="...">`) and load your script **after `config.js`** so `window.SNORQL_CONFIG` exists when it initializes:
+   ```html
+   <script src="assets/js/config.js"></script>
+   <script src="assets/js/<feature>.js"></script>
+   ```
+
+4. **Treat config as untrusted input.** Config can arrive via git, mounted files, or third-party PRs and is rendered into the DOM, so sanitize at the boundary:
+   - Write text via `textContent` / `createTextNode` — **never** `innerHTML`.
+   - Allowlist URL schemes (e.g. `http`/`https`/`mailto`) with the `URL` parser; reject everything else (defeats `javascript:`/`data:`).
+   - Allowlist any class/attribute suffix you compose (e.g. `^[a-z0-9-]+$` for a glyphicon suffix).
+   - Add `rel="noopener noreferrer"` to any link that opens in a new tab.
+   See the `escapeLinkoutText` / `sanitizeLinkoutUrl` / `buildLinkoutNode` helpers in `linkouts.js`. **Do not weaken these in review** — they are correctness requirements, not style.
+
+5. **Tests.** Add `__tests__/<feature>.test.js` mirroring the existing vm-sandbox + jsdom harness in `__tests__/sparql.test.js` and `__tests__/linkouts.test.js`: read the source file, run it in a `vm` context with a real jsdom `document`/`window`/`URL`, pull the namespace off the sandbox, and assert on real DOM nodes. Cover the sanitizers (rejected inputs), the empty/absent-config path, and render order/attributes.
+
+6. **Docs.** Add a brief subsection to `README.md` (Customization) and a full reference to `FORK.md` (field table + any Docker config-file override + the trust-boundary rationale). Cross-link back here.
+
+Following this pattern keeps features opt-in, testable in isolation, safe against untrusted config, and cheap for downstream forks to adopt — which is the whole point of landing them here rather than in a fork.

--- a/FORK.md
+++ b/FORK.md
@@ -64,8 +64,50 @@ All configuration lives in `assets/js/config.js`. Edit this file to customize th
 | `renderers.enableSVGRenderer` | `false` | When `true`, renders SVG content inline in result table cells instead of showing the raw markup. |
 | `renderers.enableSMILESRenderer` | `false` | When `true`, renders SMILES chemical structure strings as images via the CDKDepict service. Only useful for chemistry datasets. |
 | `namespaces` | 7 standard prefixes | RDF namespace prefix mappings used to display compact QNames (e.g., `rdfs:label` instead of full URIs) in query results. |
+| `linkouts` | `[]` (empty) | Ordered array of navbar linkout buttons, each `{ label, url, authors?, icon? }`, rendered by `assets/js/linkouts.js`. Empty (the default) renders none. See [Navbar Linkouts](#navbar-linkouts) below. |
 
-**Note:** For Docker deployments, three fields (`endpoint`, `title`, `examplesRepo`) are set via `.env` environment variables and injected at container startup. All other `config.js` fields must be edited directly in the file.
+**Note:** For Docker deployments, three fields (`endpoint`, `title`, `examplesRepo`) are set via `.env` environment variables and injected at container startup. All other `config.js` fields (including `linkouts`) must be edited directly in the file — see the Docker note under [Navbar Linkouts](#navbar-linkouts) for the config-file override path.
+
+## Navbar Linkouts
+
+Add tutorial, documentation, or credit buttons to the navbar entirely through configuration — no source edits per instance. Define an ordered `linkouts` array on `window.SNORQL_CONFIG` in `assets/js/config.js`:
+
+```javascript
+linkouts: [
+  { label: "Tutorial", url: "https://example.org/tutorial", icon: "book" },
+  { label: "Credits",  url: "https://example.org/about", authors: "Jane Doe et al." }
+]
+```
+
+Each entry's fields:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `label` | yes | Button text. Rendered as plain text — any HTML is escaped. |
+| `url` | yes | Link target. Only `http:`, `https:`, and `mailto:` schemes are allowed; `javascript:`/`data:` (and obfuscated variants) are rejected and the entry is skipped. |
+| `authors` | no | Attribution string. When present it becomes the button's accessible name (`aria-label`/`title`); otherwise `label` is used. |
+| `icon` | no | A Bootstrap-3 glyphicon suffix (e.g. `book` → `glyphicon-book`). Allowlisted to `[a-z0-9-]`; invalid suffixes are silently dropped. |
+
+Buttons open in a new tab and carry `rel="noopener noreferrer"`. They render in array order. An empty or absent array renders no buttons and logs no console error, so the default is safe for every deployment.
+
+### Docker config-file override (linkouts is config-file-only)
+
+`linkouts` is **not** env/`.env`-injectable — unlike `endpoint`, `title`, and `examplesRepo`, it cannot be set through environment variables (a multi-line array of objects cannot be safely substituted at container start). To customize `linkouts` in a Docker deployment, bind-mount your own `config.js` over the one in the image:
+
+```yaml
+services:
+  snorql:
+    volumes:
+      - ./my-config.js:/usr/local/apache2/htdocs/assets/js/config.js:ro
+```
+
+Your mounted `config.js` must define the full `window.SNORQL_CONFIG` object (copy the in-repo file and edit the `linkouts` array).
+
+### Trust boundary — do not weaken the sanitizers
+
+The `linkouts` array is untrusted input: it travels through git, mounted files, and potentially third-party pull requests, then is rendered directly into the navbar DOM. `assets/js/linkouts.js` therefore (1) writes `label`/`authors` via `textContent` only — never `innerHTML` — and (2) allowlists URL schemes to `http`/`https`/`mailto`. These are correctness requirements, not stylistic choices. Removing the escaping reintroduces XSS via a crafted label; removing the scheme check reintroduces `javascript:` execution via a crafted URL.
+
+Linkouts is the reference example for adding new config-driven UI features — see [CONTRIBUTING.md](CONTRIBUTING.md#config-driven-ui-extensions).
 
 ## Adding SPARQL Examples
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,21 @@ Create the directory first: `mkdir virtuoso-data`
 | Logo | `assets/images/` | Replace logo files |
 | Footer | `index.html` | Edit footer section |
 | Namespaces | `assets/js/config.js` | `namespaces` object in `SNORQL_CONFIG` |
+| Navbar linkouts | `assets/js/config.js` | `linkouts` array in `SNORQL_CONFIG` (see below) |
 | Bitly token | `assets/js/script.js` | `accessToken` (line 180) |
+
+### Navbar Linkouts
+
+Add navbar buttons (tutorials, docs, credit links) through config — no source edits. Set the `linkouts` array in `assets/js/config.js`:
+
+```javascript
+linkouts: [
+  { label: "Tutorial", url: "https://example.org/tutorial", icon: "book" },
+  { label: "Credits",  url: "https://example.org/about", authors: "Jane Doe et al." }
+]
+```
+
+Each entry is `{ label, url, authors?, icon? }`. Labels render as escaped plain text and URLs are restricted to `http`/`https`/`mailto`, so the array is safe to populate from config or mounted files. Buttons open in a new tab in array order; an empty array (the default) renders nothing. For the full field reference, the trust-boundary rationale, and the Docker config-file override path, see **[FORK.md → Navbar Linkouts](FORK.md#navbar-linkouts)**. To add a new feature in this config-driven style, see **[CONTRIBUTING.md](CONTRIBUTING.md#config-driven-ui-extensions)**.
 
 ### Branding
 

--- a/__tests__/linkouts.test.js
+++ b/__tests__/linkouts.test.js
@@ -200,4 +200,31 @@ describe('render', () => {
     var node = Linkouts.buildLinkoutNode({ label: 'Bad', url: 'javascript:alert(1)' });
     expect(node).toBeNull();
   });
+
+  test('anchor carries the snorql-linkout hook class', () => {
+    var node = Linkouts.buildLinkoutNode({ label: 'Home', url: 'https://example.org' });
+    var anchor = node.querySelector('a');
+    expect(anchor.classList.contains('snorql-linkout')).toBe(true);
+  });
+});
+
+describe('styling', () => {
+  test('renderLinkouts injects the stylesheet once', () => {
+    var existing = document.getElementById('snorql-linkout-styles');
+    if (existing) existing.remove();
+    var mount = document.createElement('ul');
+    Linkouts.renderLinkouts({ linkouts: [{ label: 'X', url: 'https://e.org' }] }, mount);
+    expect(document.querySelectorAll('#snorql-linkout-styles').length).toBe(1);
+    // A second render must not duplicate the style element.
+    Linkouts.renderLinkouts({ linkouts: [{ label: 'Y', url: 'https://e.org' }] }, mount);
+    expect(document.querySelectorAll('#snorql-linkout-styles').length).toBe(1);
+  });
+
+  test('empty config injects no stylesheet', () => {
+    var existing = document.getElementById('snorql-linkout-styles');
+    if (existing) existing.remove();
+    var mount = document.createElement('ul');
+    Linkouts.renderLinkouts({ linkouts: [] }, mount);
+    expect(document.getElementById('snorql-linkout-styles')).toBeNull();
+  });
 });

--- a/__tests__/linkouts.test.js
+++ b/__tests__/linkouts.test.js
@@ -1,0 +1,203 @@
+/**
+ * Tests for linkouts.js - config-driven navbar linkout buttons.
+ *
+ * Mirrors the vm-sandbox harness from sparql.test.js: read linkouts.js via
+ * fs.readFileSync, run it in a vm context that shares jsdom's real document/URL,
+ * then pull the exposed `Linkouts` namespace off the sandbox.
+ *
+ * testEnvironment is jsdom (jest.config.js), so document, window, and URL are real.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const linkoutsPath = path.join(__dirname, '../assets/js/linkouts.js');
+const linkoutsCode = fs.readFileSync(linkoutsPath, 'utf8');
+
+let Linkouts;
+
+beforeEach(() => {
+  // Reuse jsdom's real DOM/URL/location so anchors and new URL() behave like a browser.
+  const sandbox = {
+    window: { location: { href: 'http://localhost/' } },
+    document: document,
+    URL: URL,
+    console: console
+  };
+  // Mirror window.location onto the global location the way the browser exposes it.
+  sandbox.window.location = window.location;
+
+  vm.createContext(sandbox);
+  vm.runInContext(linkoutsCode, sandbox);
+  Linkouts = sandbox.Linkouts;
+});
+
+describe('Linkouts namespace', () => {
+  test('exposes the four helpers', () => {
+    expect(Linkouts).toBeDefined();
+    expect(typeof Linkouts.sanitizeLinkoutUrl).toBe('function');
+    expect(typeof Linkouts.escapeLinkoutText).toBe('function');
+    expect(typeof Linkouts.buildLinkoutNode).toBe('function');
+    expect(typeof Linkouts.renderLinkouts).toBe('function');
+  });
+});
+
+describe('scheme', () => {
+  test('rejects javascript: scheme', () => {
+    expect(Linkouts.sanitizeLinkoutUrl('javascript:alert(1)')).toBeNull();
+  });
+
+  test('rejects obfuscated/whitespace JAVASCRIPT: scheme', () => {
+    expect(Linkouts.sanitizeLinkoutUrl('  JAVASCRIPT:alert(1)')).toBeNull();
+  });
+
+  test('rejects data: scheme', () => {
+    expect(Linkouts.sanitizeLinkoutUrl('data:text/html,<script>')).toBeNull();
+  });
+
+  test('rejects empty / non-string input', () => {
+    expect(Linkouts.sanitizeLinkoutUrl('')).toBeNull();
+    expect(Linkouts.sanitizeLinkoutUrl('   ')).toBeNull();
+    expect(Linkouts.sanitizeLinkoutUrl(null)).toBeNull();
+    expect(Linkouts.sanitizeLinkoutUrl(undefined)).toBeNull();
+    expect(Linkouts.sanitizeLinkoutUrl(42)).toBeNull();
+  });
+
+  test('accepts http, https and mailto schemes', () => {
+    expect(Linkouts.sanitizeLinkoutUrl('http://example.org')).not.toBeNull();
+    expect(Linkouts.sanitizeLinkoutUrl('https://example.org')).not.toBeNull();
+    expect(Linkouts.sanitizeLinkoutUrl('mailto:a@b.com')).not.toBeNull();
+  });
+});
+
+describe('escape', () => {
+  test('label with HTML renders as plain text with no child element', () => {
+    var node = Linkouts.buildLinkoutNode({
+      label: '<img src=x onerror=alert(1)>',
+      url: 'https://example.org'
+    });
+    expect(node).not.toBeNull();
+    var anchor = node.querySelector('a');
+    expect(anchor).not.toBeNull();
+    // No injected element (e.g. <img>) — the markup must be inert text.
+    expect(anchor.querySelector('img')).toBeNull();
+    expect(anchor.getElementsByTagName('*').length).toBe(0);
+    expect(anchor.textContent).toBe('<img src=x onerror=alert(1)>');
+  });
+
+  test('escapeLinkoutText neutralises angle brackets', () => {
+    var escaped = Linkouts.escapeLinkoutText('<b>x</b>');
+    expect(escaped).not.toContain('<b>');
+    expect(escaped).toContain('&lt;');
+  });
+});
+
+describe('empty', () => {
+  test('undefined linkouts does not throw and appends nothing', () => {
+    var mount = document.createElement('ul');
+    expect(() => Linkouts.renderLinkouts({}, mount)).not.toThrow();
+    expect(mount.children.length).toBe(0);
+  });
+
+  test('empty array does not throw and appends nothing', () => {
+    var mount = document.createElement('ul');
+    expect(() => Linkouts.renderLinkouts({ linkouts: [] }, mount)).not.toThrow();
+    expect(mount.children.length).toBe(0);
+  });
+
+  test('null mount element does not throw', () => {
+    expect(() => Linkouts.renderLinkouts({ linkouts: [{ label: 'x', url: 'https://e.org' }] }, null)).not.toThrow();
+  });
+
+  test('null config does not throw', () => {
+    var mount = document.createElement('ul');
+    expect(() => Linkouts.renderLinkouts(null, mount)).not.toThrow();
+    expect(mount.children.length).toBe(0);
+  });
+});
+
+describe('order', () => {
+  test('three valid entries render as three <li> in config order', () => {
+    var mount = document.createElement('ul');
+    Linkouts.renderLinkouts({
+      linkouts: [
+        { label: 'First', url: 'https://a.org' },
+        { label: 'Second', url: 'https://b.org' },
+        { label: 'Third', url: 'https://c.org' }
+      ]
+    }, mount);
+    expect(mount.children.length).toBe(3);
+    expect(mount.children[0].textContent).toContain('First');
+    expect(mount.children[1].textContent).toContain('Second');
+    expect(mount.children[2].textContent).toContain('Third');
+  });
+
+  test('entries with rejected URLs are skipped', () => {
+    var mount = document.createElement('ul');
+    Linkouts.renderLinkouts({
+      linkouts: [
+        { label: 'Good', url: 'https://a.org' },
+        { label: 'Bad', url: 'javascript:alert(1)' }
+      ]
+    }, mount);
+    expect(mount.children.length).toBe(1);
+    expect(mount.children[0].textContent).toContain('Good');
+  });
+});
+
+describe('attributes', () => {
+  test('anchor has target, rel and accessible name', () => {
+    var node = Linkouts.buildLinkoutNode({
+      label: 'Tutorial',
+      url: 'https://example.org/tutorial'
+    });
+    var anchor = node.querySelector('a');
+    expect(anchor.getAttribute('target')).toBe('_blank');
+    expect(anchor.getAttribute('rel')).toBe('noopener noreferrer');
+    // Accessible name from label when no authors given.
+    var accName = anchor.getAttribute('aria-label') || anchor.getAttribute('title');
+    expect(accName).toBe('Tutorial');
+  });
+
+  test('authors override the accessible name', () => {
+    var node = Linkouts.buildLinkoutNode({
+      label: 'Tutorial',
+      url: 'https://example.org/tutorial',
+      authors: 'Jane Doe'
+    });
+    var anchor = node.querySelector('a');
+    var accName = anchor.getAttribute('aria-label') || anchor.getAttribute('title');
+    expect(accName).toBe('Jane Doe');
+  });
+
+  test('valid glyphicon suffix renders an icon span; invalid suffix is dropped', () => {
+    var good = Linkouts.buildLinkoutNode({
+      label: 'Doc', url: 'https://example.org', icon: 'book'
+    });
+    expect(good.querySelector('span.glyphicon.glyphicon-book')).not.toBeNull();
+
+    var bad = Linkouts.buildLinkoutNode({
+      label: 'Doc', url: 'https://example.org', icon: 'book"><script>'
+    });
+    // No span injected for a disallowed icon suffix.
+    expect(bad.querySelector('span.glyphicon')).toBeNull();
+  });
+});
+
+describe('render', () => {
+  test('a valid {label,url} entry produces one <li><a> button', () => {
+    var node = Linkouts.buildLinkoutNode({ label: 'Home', url: 'https://example.org' });
+    expect(node).not.toBeNull();
+    expect(node.tagName).toBe('LI');
+    var anchor = node.querySelector('a');
+    expect(anchor).not.toBeNull();
+    expect(anchor.getAttribute('href')).toContain('example.org');
+    expect(anchor.textContent).toBe('Home');
+  });
+
+  test('an entry with a rejected URL yields null', () => {
+    var node = Linkouts.buildLinkoutNode({ label: 'Bad', url: 'javascript:alert(1)' });
+    expect(node).toBeNull();
+  });
+});

--- a/assets/js/config.js
+++ b/assets/js/config.js
@@ -10,6 +10,22 @@ window.SNORQL_CONFIG = {
         enableSVGRenderer: false,
         enableSMILESRenderer: false
     },
+    // Optional navbar linkout buttons, rendered in array order by linkouts.js.
+    // Keep the live default EMPTY so existing deployments render unchanged.
+    // Each entry: { label, url, authors?, icon? }
+    //   label   - button text (shown as plain text; HTML is escaped)
+    //   url     - http/https/mailto only; other schemes (javascript:/data:) are rejected
+    //   authors - optional; used as the accessible name (aria-label/title) when present
+    //   icon    - optional Bootstrap-3 glyphicon suffix, e.g. "book" -> glyphicon-book
+    //             (allowlisted to [a-z0-9-]; invalid suffixes are dropped)
+    // SECURITY: this array is untrusted input — do not remove the escaping or
+    // the URL scheme allowlist in assets/js/linkouts.js. See FORK.md.
+    // Example:
+    //   linkouts: [
+    //     { label: "Tutorial", url: "https://example.org/tutorial", icon: "book" },
+    //     { label: "Credits",  url: "https://example.org/about", authors: "Jane Doe et al." }
+    //   ],
+    linkouts: [],
     namespaces: {
         rdf: "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
         rdfs: "http://www.w3.org/2000/01/rdf-schema#",

--- a/assets/js/linkouts.js
+++ b/assets/js/linkouts.js
@@ -23,6 +23,34 @@
 
     var SAFE_SCHEMES = ['http:', 'https:', 'mailto:'];
     var ICON_SUFFIX = /^[a-z0-9-]+$/;
+    var STYLE_ID = 'snorql-linkout-styles';
+
+    // Theme-adaptive "ghost button" styling so linkouts read as buttons (not
+    // faint text links) and are spaced from the rest of the navbar. Border and
+    // text use the inherited navbar link color (currentColor), so this adapts to
+    // any navbar theme without hardcoding a palette. Scoped to #navbar-linkouts
+    // (the conventional mount id) with id-level specificity so it wins over
+    // Bootstrap's .navbar-nav>li>a rules. This is a CONSTANT string — no config
+    // values are interpolated, so injecting it is not an XSS surface. Deployers
+    // can override by defining their own .snorql-linkout rules.
+    var LINKOUT_CSS =
+        '#navbar-linkouts .snorql-linkout{display:inline-block;margin:8px 4px;' +
+        'padding:6px 12px;border:1px solid currentColor;border-radius:4px;' +
+        'line-height:1.42857143;opacity:.92}' +
+        '#navbar-linkouts .snorql-linkout:hover,' +
+        '#navbar-linkouts .snorql-linkout:focus{text-decoration:none;opacity:1;' +
+        'background-color:rgba(127,127,127,.18)}';
+
+    // Inject the stylesheet once, on first render. Skipped when there are no
+    // linkouts (renderLinkouts returns early), so an empty config adds nothing.
+    function ensureLinkoutStyles() {
+        if (typeof document === 'undefined' || !document.head) return;
+        if (document.getElementById(STYLE_ID)) return;
+        var style = document.createElement('style');
+        style.id = STYLE_ID;
+        style.appendChild(document.createTextNode(LINKOUT_CSS));
+        document.head.appendChild(style);
+    }
 
     // Verbatim copy of snorql.js escapeHtml (createTextNode -> innerHTML).
     // innerHTML here is a READ of escaped text, never a write of config values.
@@ -54,6 +82,7 @@
         var li = document.createElement('li');
         var a = document.createElement('a');
 
+        a.className = 'snorql-linkout';
         a.setAttribute('href', href);
         a.setAttribute('target', '_blank');
         a.setAttribute('rel', 'noopener noreferrer');
@@ -88,6 +117,7 @@
     function renderLinkouts(config, mountEl) {
         if (!config || !Array.isArray(config.linkouts) || config.linkouts.length === 0) return;
         if (!mountEl) return;
+        ensureLinkoutStyles();
         for (var i = 0; i < config.linkouts.length; i++) {
             var node = buildLinkoutNode(config.linkouts[i]);
             if (node) mountEl.appendChild(node);

--- a/assets/js/linkouts.js
+++ b/assets/js/linkouts.js
@@ -1,0 +1,122 @@
+/**
+ * linkouts.js - config-driven navbar linkout buttons.
+ *
+ * A deployer defines an ordered `linkouts` array on window.SNORQL_CONFIG. Each
+ * entry: { label, url, authors?, icon? }. This module sanitises every field and
+ * renders Bootstrap-3 navbar <li><a> buttons into #navbar-linkouts.
+ *
+ * SECURITY / TRUST BOUNDARY: the linkouts config is UNTRUSTED input. It travels
+ * through git, mounted files, and potentially third-party PRs, then is rendered
+ * into the navbar DOM. Therefore:
+ *   - label/authors are written via textContent only (never innerHTML)
+ *   - url schemes are allowlisted to http/https/mailto (defeats javascript:/data:)
+ *   - icon suffixes are allowlisted to [a-z0-9-] before composing a glyphicon class
+ *   - every anchor carries rel="noopener noreferrer" (reverse-tabnabbing guard)
+ * Do NOT "simplify" these away.
+ *
+ * Self-contained: no module system; vendored-globals style. The escape helper is
+ * inlined (a verbatim copy of snorql.js's escapeHtml) rather than imported, to
+ * avoid load-order coupling and to keep the module unit-testable in isolation.
+ */
+(function () {
+    'use strict';
+
+    var SAFE_SCHEMES = ['http:', 'https:', 'mailto:'];
+    var ICON_SUFFIX = /^[a-z0-9-]+$/;
+
+    // Verbatim copy of snorql.js escapeHtml (createTextNode -> innerHTML).
+    // innerHTML here is a READ of escaped text, never a write of config values.
+    function escapeLinkoutText(str) {
+        var div = document.createElement('div');
+        div.appendChild(document.createTextNode(String(str == null ? '' : str)));
+        return div.innerHTML;
+    }
+
+    function sanitizeLinkoutUrl(raw) {
+        if (typeof raw !== 'string' || raw.trim() === '') return null;
+        try {
+            var base = (typeof window !== 'undefined' && window.location)
+                ? window.location.href
+                : 'http://localhost/';
+            var u = new URL(raw, base);
+            return SAFE_SCHEMES.indexOf(u.protocol) !== -1 ? u.href : null;
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function buildLinkoutNode(entry) {
+        if (!entry || typeof entry !== 'object') return null;
+
+        var href = sanitizeLinkoutUrl(entry.url);
+        if (href === null) return null;
+
+        var li = document.createElement('li');
+        var a = document.createElement('a');
+
+        a.setAttribute('href', href);
+        a.setAttribute('target', '_blank');
+        a.setAttribute('rel', 'noopener noreferrer');
+
+        // Optional glyphicon: allowlist the suffix, compose the class on a child
+        // span. Never inject raw entry.icon into a class or via innerHTML.
+        if (typeof entry.icon === 'string' && ICON_SUFFIX.test(entry.icon)) {
+            var icon = document.createElement('span');
+            icon.className = 'glyphicon glyphicon-' + entry.icon;
+            icon.setAttribute('aria-hidden', 'true');
+            a.appendChild(icon);
+            a.appendChild(document.createTextNode(' '));
+        }
+
+        // Label is untrusted text — textContent only, never innerHTML.
+        a.appendChild(document.createTextNode(String(entry.label == null ? '' : entry.label)));
+
+        // Accessible name for icon-only buttons; authors override label.
+        var name = String(
+            (entry.authors != null && entry.authors !== '') ? entry.authors :
+            (entry.label != null ? entry.label : '')
+        );
+        if (name !== '') {
+            a.setAttribute('title', name);
+            a.setAttribute('aria-label', name);
+        }
+
+        li.appendChild(a);
+        return li;
+    }
+
+    function renderLinkouts(config, mountEl) {
+        if (!config || !Array.isArray(config.linkouts) || config.linkouts.length === 0) return;
+        if (!mountEl) return;
+        for (var i = 0; i < config.linkouts.length; i++) {
+            var node = buildLinkoutNode(config.linkouts[i]);
+            if (node) mountEl.appendChild(node);
+        }
+    }
+
+    // Expose helpers to the vm sandbox (used by __tests__/linkouts.test.js) and,
+    // in a browser, to window for debugging.
+    var Linkouts = {
+        escapeLinkoutText: escapeLinkoutText,
+        sanitizeLinkoutUrl: sanitizeLinkoutUrl,
+        buildLinkoutNode: buildLinkoutNode,
+        renderLinkouts: renderLinkouts
+    };
+    // `this` is the sandbox/global the IIFE is invoked against (see .call() below),
+    // letting __tests__/linkouts.test.js pull `Linkouts` off the vm sandbox.
+    this.Linkouts = Linkouts;
+
+    // Self-init in the browser. Guard the DOMContentLoaded race (Pitfall 4): if
+    // the document already finished parsing, render immediately; otherwise wait.
+    if (typeof window !== 'undefined' && typeof document !== 'undefined' && document.addEventListener) {
+        window.renderLinkouts = renderLinkouts;
+        var init = function () {
+            renderLinkouts(window.SNORQL_CONFIG, document.getElementById('navbar-linkouts'));
+        };
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', init);
+        } else {
+            init();
+        }
+    }
+}).call(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
     <script src="assets/js/sparql.js"></script>
     <script src="assets/js/mustache.min.js"></script>
     <script src="assets/js/config.js"></script>
+    <script src="assets/js/linkouts.js"></script>
     <script src="assets/js/snorql.js"></script>
 	<script src="assets/js/script.js"></script>
   </head>
@@ -41,8 +42,8 @@
 		  <a class="navbar-brand" id="index-page" href=""><img src="assets/images/wikipathways-snorql-logo.png" width="200" height="50" /></a>
         </div>
         <div id="navbar" class="navbar-collapse collapse">
-		  <ul class="nav navbar-nav">
-		  </ul>	
+		  <ul class="nav navbar-nav" id="navbar-linkouts">
+		  </ul>
           <form class="navbar-form navbar-right">
             <div class="input-group">
 				<span class="input-group-addon">SPARQL Endpoint</span>


### PR DESCRIPTION
Adds an optional, config-driven way to render linkout buttons (tutorials, docs, credits) in the navbar — no per-instance source edits. Implements the feature requested in #21.

## What
- **New `assets/js/linkouts.js`** — reads `window.SNORQL_CONFIG.linkouts` (an ordered array of `{ label, url, authors?, icon? }`) and renders Bootstrap-3 navbar buttons into `#navbar-linkouts`. Self-contained IIFE, self-initialises on `DOMContentLoaded`.
- **`linkouts: []`** config key added to `assets/js/config.js` (empty default — existing deployments render unchanged).
- **`index.html`** — loads `linkouts.js` right after `config.js`; adds `id="navbar-linkouts"` to the existing (empty) navbar `<ul>`.
- **Docs** — "Navbar Linkouts" sections in `README.md` (brief) and `FORK.md` (full field reference + Docker config-file override + trust-boundary rationale).
- **`CONTRIBUTING.md`** (new) — documents the **config-driven UI extension pattern**, using linkouts as the reference example, so future optional features follow the same isolated, testable, safe-by-default shape.
- **Tests** — `__tests__/linkouts.test.js` (19 cases) mirroring the existing `sparql.test.js` vm/jsdom harness.

## Security
The `linkouts` array is treated as untrusted input: `label`/`authors` are written via `textContent` only (never `innerHTML`), URL schemes are allowlisted to `http`/`https`/`mailto` (rejects `javascript:`/`data:` and obfuscated variants), glyphicon suffixes are allowlisted to `[a-z0-9-]`, and every anchor carries `rel="noopener noreferrer"`. These are covered by unit tests.

## Backwards compatibility
Default `linkouts: []` renders nothing — no behavioural change for current deployments.

## Verification
`npm ci && npm run lint && npm test` all green (0 lint errors; 125 tests across 5 suites, incl. 19 new linkouts cases). Browser-checked: empty default renders no buttons with no console errors; a sample array renders buttons in order with correct attributes; a `javascript:` entry is rejected and an HTML label is escaped.

Closes #21